### PR TITLE
[S20-126] [minor] fix: img position in spoti-table component

### DIFF
--- a/frontend/src/sass/components/_spoti-table.scss
+++ b/frontend/src/sass/components/_spoti-table.scss
@@ -5,7 +5,9 @@
 
 .collection_index p {
     display: flex;
-    margin-right: 2em;
+    width: 2em;
+    text-align: center;
+    margin-right: .25em;
 }
 
 .collection_description {
@@ -82,6 +84,6 @@
 }
 
 
-.collection_description .collection_title, .collection_description .collection_songs_count, .track_description { 
+.collection_description .collection_title, .collection_description .collection_songs_count, .track_description {
     text-align: left;
 }


### PR DESCRIPTION
**FROM**
![image](https://user-images.githubusercontent.com/44068045/172389166-d106d6eb-bdc2-4c1e-aca9-0a9021de4189.png)
**TO**
![image](https://user-images.githubusercontent.com/44068045/172389124-99bdc4af-38b4-4eb8-8a1f-d14451f99922.png)
